### PR TITLE
Extract attachments and store in S3 bucket with unguessable url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 function.zip
 v-env/
 .vscode/
+__pycache__/
+.pytest_cache
+.terraform/
+.DS_Store

--- a/Pipfile
+++ b/Pipfile
@@ -4,9 +4,14 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+moto = "*"
+boto3 = "*"
+pytest = "*"
+requests_mock = "*"
 
 [packages]
 requests = "*"
+bleach = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb57e0d7853b45999e47c163c46b95bc2fde31c527d8d7b5b5539dc979444a6d"
+            "sha256": "fffa44a838358fc08f9b0ef4cc2ca3fab73d51d77430900534095d16ccd8b217"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,12 +16,20 @@
         ]
     },
     "default": {
+        "bleach": {
+            "hashes": [
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -45,13 +53,498 @@
             "index": "pypi",
             "version": "==2.22.0"
         },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
-                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.6"
+            "version": "==1.25.8"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "aws-sam-translator": {
+            "hashes": [
+                "sha256:ddf61fdabc94a66ca0a3e7d042d6a0e508bc45bd128c86fb02af0c87a59ac79e"
+            ],
+            "version": "==1.20.1"
+        },
+        "aws-xray-sdk": {
+            "hashes": [
+                "sha256:263a38f3920d9dc625e3acb92e6f6d300f4250b70f538bd009ce6e485676ab74",
+                "sha256:612dba6efc3704ef224ac0747b05488b8aad94e71be3ece4edbc051189d50482"
+            ],
+            "version": "==2.4.3"
+        },
+        "boto": {
+            "hashes": [
+                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
+                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
+            ],
+            "version": "==2.49.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:05f7ae180813fbf11cb7397b43b6bd29463abdc246bee58127836f1a8f6a9a2f",
+                "sha256:3480c87b530e7f41d9264a6725dda68208de2697822cf02cd3a541b001872410"
+            ],
+            "index": "pypi",
+            "version": "==1.11.9"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:1909424c9544f92142c8e551888731e32a99f9c99cfe8d21fea3ec0c32981dae",
+                "sha256:e3e3c0f59dc30c86dd2116aece3bd554f8476446cf1c5770bbf5111993d676c8"
+            ],
+            "version": "==1.14.9"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
+                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
+                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
+                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
+                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
+                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
+                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
+                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
+                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
+                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
+                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
+                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
+                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
+                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
+                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
+                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
+                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
+                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
+                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
+                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
+                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
+                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
+                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
+                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
+                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
+                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
+                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
+                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
+                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
+                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
+                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
+                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
+                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+            ],
+            "version": "==1.13.2"
+        },
+        "cfn-lint": {
+            "hashes": [
+                "sha256:0347f46893cff64ca3e2390463de18739b5f2a160305af51ba76ee4bb35c3bb6",
+                "sha256:7512db604043fbccb65a484e1898cf01b3198747cee6aeca720cc0c77010177a"
+            ],
+            "version": "==0.27.2"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
+                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
+                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
+                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
+                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
+                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
+                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
+                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
+                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
+                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
+                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
+                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
+                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
+                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
+                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
+                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
+                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
+                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
+                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
+                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
+                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+            ],
+            "version": "==2.8"
+        },
+        "docker": {
+            "hashes": [
+                "sha256:6e06c5e70ba4fad73e35f00c55a895a448398f3ada7faae072e2bb01348bafc1",
+                "sha256:8f93775b8bdae3a2df6bc9a5312cce564cade58d6555f2c2570165a1270cd8a7"
+            ],
+            "version": "==4.1.0"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "version": "==0.15.2"
+        },
+        "ecdsa": {
+            "hashes": [
+                "sha256:867ec9cf6df0b03addc8ef66b56359643cb5d0c1dc329df76ba7ecfe256c8061",
+                "sha256:8f12ac317f8a1318efa75757ef0a651abe12e51fc1af8838fb91079445227277"
+            ],
+            "version": "==0.15"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "version": "==0.18.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
+                "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.4.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:6e7a3c2934694d59ad334c93dd1b6c96699cf24c53fdb8ec848ac6b23e685734",
+                "sha256:d6609ae5ec3d56212ca7d802eda654eaf2310000816ce815361041465b108be4"
+            ],
+            "version": "==2.11.0"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+            ],
+            "version": "==0.9.4"
+        },
+        "jsondiff": {
+            "hashes": [
+                "sha256:7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21"
+            ],
+            "version": "==1.1.2"
+        },
+        "jsonpatch": {
+            "hashes": [
+                "sha256:83f29a2978c13da29bfdf89da9d65542d62576479caf215df19632d7dc04c6e6",
+                "sha256:cbb72f8bf35260628aea6b508a107245f757d1ec839a19c34349985e2c05645a"
+            ],
+            "version": "==1.24"
+        },
+        "jsonpickle": {
+            "hashes": [
+                "sha256:d0c5a4e6cb4e58f6d5406bdded44365c2bcf9c836c4f52910cc9ba7245a59dc2",
+                "sha256:d3e922d781b1d0096df2dad89a2e1f47177d7969b596aea806a9d91b4626b29b"
+            ],
+            "version": "==1.2"
+        },
+        "jsonpointer": {
+            "hashes": [
+                "sha256:c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362",
+                "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"
+            ],
+            "version": "==2.0"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "version": "==3.2.0"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+            ],
+            "version": "==1.1.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3",
+                "sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"
+            ],
+            "version": "==3.0.5"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39",
+                "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"
+            ],
+            "version": "==8.1.0"
+        },
+        "moto": {
+            "hashes": [
+                "sha256:2b3fa22778504b45715868cad95ad458fdea7227f9005b12e522fc9c2ae0cabc",
+                "sha256:79aeaeed1592a24d3c488840065a3fcb3f4fa7ba40259e112482454c0e48a03a"
+            ],
+            "index": "pypi",
+            "version": "==1.3.14"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
+                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
+            ],
+            "version": "==20.1"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+            ],
+            "version": "==0.4.8"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+            ],
+            "version": "==2.4.6"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:cdc7b5e3ed77bed61270a47d35434a30617b9becdf2478af76ad2c6ade307280"
+            ],
+            "version": "==0.15.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600",
+                "sha256:c13d1943c63e599b98cf118fcb9703e4d7bde7caa9a432567bcdcae4bf512d20"
+            ],
+            "index": "pypi",
+            "version": "==5.3.4"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "python-jose": {
+            "hashes": [
+                "sha256:1ac4caf4bfebd5a70cf5bd82702ed850db69b0b6e1d0ae7368e5f99ac01c9571",
+                "sha256:8484b7fdb6962e9d242cce7680469ecf92bda95d10bbcbbeb560cacdff3abfce"
+            ],
+            "version": "==3.1.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6",
+                "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf",
+                "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5",
+                "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e",
+                "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811",
+                "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e",
+                "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d",
+                "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20",
+                "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689",
+                "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994",
+                "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==5.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
+        "requests-mock": {
+            "hashes": [
+                "sha256:510df890afe08d36eca5bb16b4aa6308a6f85e3159ad3013bac8b9de7bd5a010",
+                "sha256:88d3402dd8b3c69a9e4f9d3a73ad11b15920c6efd36bc27bf1f701cf4a8e4646"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
+        },
+        "responses": {
+            "hashes": [
+                "sha256:515fd7c024097e5da76e9c4cf719083d181f1c3ddc09c2e0e49284ce863dd263",
+                "sha256:8ce8cb4e7e1ad89336f8865af152e0563d2e7f0e0b86d2cf75f015f819409243"
+            ],
+            "version": "==0.10.9"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2525bae2a530195576da53671bae8ca8c55ee8e33bc2225a65e804476611ea5a",
+                "sha256:4924e10451cc37901945806423d16c2c2040a6530645a614ed87e995ccec764c"
+            ],
+            "version": "==0.3.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "sshpubkeys": {
+            "hashes": [
+                "sha256:9f73d51c2ef1e68cd7bde0825df29b3c6ec89f4ce24ebca3bf9eaa4a23a284db",
+                "sha256:b388399caeeccdc145f06fd0d2665eeecc545385c60b55c282a15a022215af80"
+            ],
+            "version": "==3.1.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+            ],
+            "version": "==1.25.8"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+            ],
+            "version": "==0.1.8"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549",
+                "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"
+            ],
+            "version": "==0.57.0"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
+                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+            ],
+            "version": "==0.16.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+            ],
+            "version": "==1.11.2"
+        },
+        "xmltodict": {
+            "hashes": [
+                "sha256:50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21",
+                "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"
+            ],
+            "version": "==0.12.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
+                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
+            ],
+            "version": "==2.1.0"
+        }
+    }
 }

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -6,8 +6,9 @@ from uuid import uuid4
 from email import policy, message_from_bytes
 from os import getenv
 import boto3
-
-DEBUG = int(getenv("DEBUG", "0"))
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context):
@@ -78,6 +79,7 @@ def lambda_handler(event, context):
                 "fileSizeBytes": len(file_content),
             }
         )
+    logger.info(f'### EMAIL ### From: {message.get("From")}, Subject: {message.get("Subject")}')
     bpm_data = {
         "input": [
             {

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -84,6 +84,7 @@ def lambda_handler(event, context):
                 "name": "email",
                 "data": {
                     "from": message.get("From"),
+                    "cc": message.get("Cc"),
                     "dateReceived": date_converted,
                     "subject": message.get("Subject"),
                     "body": email_content,

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,51 +1,125 @@
 import json
 import requests
+import bleach
 from datetime import datetime
+from uuid import uuid4
 from email import policy, message_from_bytes
 from os import getenv
 import boto3
 
+DEBUG = int(getenv("DEBUG", "0"))
+
 
 def lambda_handler(event, context):
-    client = boto3.client('s3')
-    s3_event = event['Records'][0]['s3']
-    email_obj = client.get_object(Bucket=s3_event['bucket']['name'], Key=s3_event['object']['key'])
+    client = boto3.client("s3")
+    s3_event = event["Records"][0]["s3"]
+    email_obj = client.get_object(
+        Bucket=s3_event["bucket"]["name"], Key=s3_event["object"]["key"]
+    )
     if email_obj == None:
-        raise Exception('Cannot access email from S3 bucket: ' + s3_event['bucket']['name'])
+        raise Exception(
+            "Cannot access email from S3 bucket: " + s3_event["bucket"]["name"]
+        )
 
-    message = message_from_bytes(email_obj['Body'].read(), policy=policy.default)
+    message = message_from_bytes(email_obj["Body"].read(), policy=policy.default)
     if message == None or len(message) == 0:
-        raise Exception('Email appears empty or unparseable: ' + s3_event['object']['key'])
+        raise Exception(
+            "Email appears empty or unparseable: " + s3_event["object"]["key"]
+        )
 
     # We get:  Wed, 7 Oct 2015 12:34:56 -0700
     # We need: ISO-8601 format 'yyyy-MM-dd'T'HH:mm:ssz'
-    date_received = datetime.strptime(message.get('Date'), r'%a, %d %b %Y %H:%M:%S %z')
-    date_converted = date_received.strftime(r'%Y-%m-%dT%H:%M:%S%z')
-    bpm_data = {'input': [
-        {'name': 'email',
-        'data': {
-            'from': message.get('From'), 
-            'dateReceived': date_converted, 
-            'subject': message.get('Subject'), 
-            'body': str(message.get_body(preferencelist=('plain')))}
-        }]}
+    date_received = datetime.strptime(message.get("Date"), r"%a, %d %b %Y %H:%M:%S %z")
+    date_converted = date_received.strftime(r"%Y-%m-%dT%H:%M:%S%z")
+    email_body_part = message.get_body(preferencelist=("related", "plain", "html"))
+    email_content = bleach.clean(
+        email_body_part.get_content(),
+        tags=[
+            "a",
+            "abbr",
+            "acronym",
+            "b",
+            "blockquote",
+            "br",
+            "code",
+            "div",
+            "em",
+            "i",
+            "li",
+            "ol",
+            "p",
+            "span",
+            "strong",
+            "ul",
+        ],
+    )
 
-    csrf_resp = requests.post(getenv('BPM_CSRF_URL'),
-        auth=(getenv('BPM_USER'), getenv('BPM_PW')),
-        json={'refresh_groups': True, 'requested_lifetime': 7200})
+    attachments = []
+    bucket = getenv("ATTACHMENT_BUCKET")
+    region = client.get_bucket_location(Bucket=bucket)["LocationConstraint"]
+
+    for attachment in message.iter_attachments():
+        key = str(uuid4()) + str(uuid4())
+        content_type = attachment.get_content_type()
+        filename = attachment.get_filename()
+        file_content = attachment.get_content()
+        client.put_object(
+            Body=file_content,
+            Bucket=bucket,
+            Key=key,
+            ContentType=content_type,
+            ContentDisposition=f'attachment; filename="{filename}"',
+        )
+        attachments.append(
+            {
+                "url": f"https://s3.{region}.amazonaws.com/{bucket}/{key}",
+                "contentType": content_type,
+                "originalFilename": filename,
+                "fileSizeBytes": len(file_content),
+            }
+        )
+    bpm_data = {
+        "input": [
+            {
+                "name": "email",
+                "data": {
+                    "from": message.get("From"),
+                    "dateReceived": date_converted,
+                    "subject": message.get("Subject"),
+                    "body": email_content,
+                    "contentType": email_body_part.get_content_type(),
+                    "attachments": attachments,
+                },
+            }
+        ]
+    }
+
+    csrf_resp = requests.post(
+        getenv("BPM_CSRF_URL"),
+        auth=(getenv("BPM_USER"), getenv("BPM_PW")),
+        json={"refresh_groups": True, "requested_lifetime": 7200},
+    )
     if csrf_resp.status_code != 201:
-        raise Exception(f'ERROR {csrf_resp.status_code}: Cannot get CSRF token: {csrf_resp.text}')
-    csrf_token = csrf_resp.json()['csrf_token']
-    
-    task_resp = requests.post(getenv('BPM_EMAIL_URL'),
-        headers={'BPMCSRFToken': csrf_token},
-        auth=(getenv('BPM_USER'), getenv('BPM_PW')),
-        json=bpm_data)
+        raise Exception(
+            f"ERROR {csrf_resp.status_code}: Cannot get CSRF token: {csrf_resp.text}"
+        )
+    csrf_token = csrf_resp.json()["csrf_token"]
+
+    task_resp = requests.post(
+        getenv("BPM_EMAIL_URL"),
+        headers={"BPMCSRFToken": csrf_token},
+        auth=(getenv("BPM_USER"), getenv("BPM_PW")),
+        json=bpm_data,
+    )
 
     if task_resp.status_code != 201:
-        raise Exception(f'ERROR {task_resp.status_code}: Cannot init new task: {task_resp.text}')
+        raise Exception(
+            f"ERROR {task_resp.status_code}: Cannot init new task: {task_resp.text}"
+        )
 
     return {
-        'status': task_resp.status_code,
-        'body': task_resp.text
+        "status": task_resp.status_code,
+        "body": task_resp.text,
+        "bpm_data": bpm_data,
+        "attachments": attachments,
     }

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -121,5 +121,4 @@ def lambda_handler(event, context):
         "status": task_resp.status_code,
         "body": task_resp.text,
         "bpm_data": bpm_data,
-        "attachments": attachments,
     }

--- a/lambdas/lambda_function.py
+++ b/lambdas/lambda_function.py
@@ -6,17 +6,26 @@ from uuid import uuid4
 from email import policy, message_from_bytes
 from os import getenv
 import boto3
+from time import time
 import logging
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 
 def lambda_handler(event, context):
+    timestamp = time()
     client = boto3.client("s3")
     s3_event = event["Records"][0]["s3"]
+    
+    bucket_name = s3_event["bucket"]["name"]
+    s3_key = s3_event["object"]["key"]
+    logger.info(f"### S3 ### Bucket: {bucket_name}; Object key: {s3_key}")
+
     email_obj = client.get_object(
-        Bucket=s3_event["bucket"]["name"], Key=s3_event["object"]["key"]
+        Bucket=bucket_name, Key=s3_key
     )
+    logger.info(f"### TIME ### Time to get email: {time() - timestamp}")
+    timestamp = time()
     if email_obj == None:
         raise Exception(
             "Cannot access email from S3 bucket: " + s3_event["bucket"]["name"]
@@ -27,12 +36,14 @@ def lambda_handler(event, context):
         raise Exception(
             "Email appears empty or unparseable: " + s3_event["object"]["key"]
         )
-
+    logger.info(f"### TIME ### Time to parse email: {time() - timestamp}")
+    timestamp = time()
     # We get:  Wed, 7 Oct 2015 12:34:56 -0700
     # We need: ISO-8601 format 'yyyy-MM-dd'T'HH:mm:ssz'
     date_received = datetime.strptime(message.get("Date"), r"%a, %d %b %Y %H:%M:%S %z")
     date_converted = date_received.strftime(r"%Y-%m-%dT%H:%M:%S%z")
     email_body_part = message.get_body(preferencelist=("related", "plain", "html"))
+    logger.debug(email_body_part)
     email_content = bleach.clean(
         email_body_part.get_content(),
         tags=[
@@ -54,31 +65,38 @@ def lambda_handler(event, context):
             "ul",
         ],
     )
-
+    logger.info(f"### TIME ### Time to sanitise html: {time() - timestamp}")
+    timestamp = time()
     attachments = []
     bucket = getenv("ATTACHMENT_BUCKET")
-    region = client.get_bucket_location(Bucket=bucket)["LocationConstraint"]
-
-    for attachment in message.iter_attachments():
-        key = str(uuid4()) + str(uuid4())
-        content_type = attachment.get_content_type()
-        filename = attachment.get_filename()
-        file_content = attachment.get_content()
-        client.put_object(
-            Body=file_content,
-            Bucket=bucket,
-            Key=key,
-            ContentType=content_type,
-            ContentDisposition=f'attachment; filename="{filename}"',
-        )
-        attachments.append(
-            {
-                "url": f"https://s3.{region}.amazonaws.com/{bucket}/{key}",
-                "contentType": content_type,
-                "originalFilename": filename,
-                "fileSizeBytes": len(file_content),
-            }
-        )
+    
+    message_iter = message.iter_attachments()
+    attachment = next(message_iter, None)
+    if attachment != None:
+        region = client.get_bucket_location(Bucket=bucket)["LocationConstraint"]
+        while attachment != None:
+            key = str(uuid4()) + str(uuid4())
+            content_type = attachment.get_content_type()
+            filename = attachment.get_filename()
+            file_content = attachment.get_content()
+            client.put_object(
+                Body=file_content,
+                Bucket=bucket,
+                Key=key,
+                ContentType=content_type,
+                ContentDisposition=f'attachment; filename="{filename}"',
+            )
+            attachments.append(
+                {
+                    "url": f"https://s3.{region}.amazonaws.com/{bucket}/{key}",
+                    "contentType": content_type,
+                    "originalFilename": filename,
+                    "fileSizeBytes": len(file_content),
+                }
+            )
+            attachment = next(message_iter, None)
+    logger.info(f"### TIME ### Time to store attachments: {time() - timestamp}")
+    timestamp = time()
     logger.info(f'### EMAIL ### From: {message.get("From")}, Subject: {message.get("Subject")}')
     bpm_data = {
         "input": [
@@ -107,7 +125,8 @@ def lambda_handler(event, context):
             f"ERROR {csrf_resp.status_code}: Cannot get CSRF token: {csrf_resp.text}"
         )
     csrf_token = csrf_resp.json()["csrf_token"]
-
+    logger.info(f"### TIME ### Time to get csrf: {time() - timestamp}")
+    timestamp = time()
     task_resp = requests.post(
         getenv("BPM_EMAIL_URL"),
         headers={"BPMCSRFToken": csrf_token},
@@ -119,7 +138,8 @@ def lambda_handler(event, context):
         raise Exception(
             f"ERROR {task_resp.status_code}: Cannot init new task: {task_resp.text}"
         )
-
+    logger.info(f"### TIME ### Time to trigger bpm: {time() - timestamp}")
+    timestamp = time()
     return {
         "status": task_resp.status_code,
         "body": task_resp.text,

--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,10 @@ You will need to set your lambda's trigger to be S3 ObjectCreated.
 
 ### Environment variables
 
-| Variable name | Description |
-| --------------|-------------|
-| BPM_CSRF_URL  | REST endpoint URL for requesting a new CSRF token |
-| BPM_EMAIL_URL | REST endpoint URL for creating a new task instance |
-| BPM_USER      | Username for accessing BPM |
-| BPM_PW        | Password for above |
+| Variable name     | Description |
+| ------------------|-------------|
+| BPM_CSRF_URL      | REST endpoint URL for requesting a new CSRF token |
+| BPM_EMAIL_URL     | REST endpoint URL for creating a new task instance |
+| BPM_USER          | Username for accessing BPM |
+| BPM_PW            | Password for above |
+| ATTACHMENT_BUCKET | S3 bucket name to store attachments in |

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -22,6 +22,11 @@ resource "aws_iam_role_policy_attachment" "add_cloudwatch" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+resource "aws_iam_role_policy_attachment" "add_s3" {
+  role       = aws_iam_role.email_lambda.name
+  policy_arn = aws_iam_policy.email-lambda-s3-policy.arn
+}
+
 resource "aws_lambda_function" "email" {
     filename = "../function.zip"
     runtime = "python3.8"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,58 @@
+resource "aws_iam_role" "email_lambda" {
+  name = "${local.prefix}-email-lambda"
+
+  assume_role_policy = <<-EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Effect": "Allow"
+            }
+        ]
+    }
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "add_cloudwatch" {
+  role       = aws_iam_role.email_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_lambda_function" "email" {
+    filename = "../function.zip"
+    runtime = "python3.8"
+    role = aws_iam_role.email_lambda.arn
+    function_name = "bpm-email-lambda"
+    handler = "lambda_function.lambda_handler"
+    description = "BPM Prices Correspondence new instance email trigger"
+    timeout = 30
+
+    environment {
+        variables = {
+            ATTACHMENT_BUCKET = local.attachments_bucket
+            BPM_CSRF_URL = "https://ons.bpm.ibmcloud.com/baw/${var.stage}/bpm/system/login"
+            BPM_EMAIL_URL = "https://ons.bpm.ibmcloud.com/baw/${var.stage}/bpm/processes?model=Prices%20Correspondence&container=PRICOR"
+        }
+    }
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.email.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.emails.arn
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = local.emails_bucket
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.email.arn
+    events              = ["s3:ObjectCreated:*"]
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
+locals  {
+    prefix = "${var.app}-${var.stage}"
+    attachments_bucket = "${local.prefix}-attachments-in.${var.domain}"
+    emails_bucket = "${local.prefix}-emails.${var.domain}"
+}
+
+terraform {
+  backend "s3" {
+    bucket               = "terraform.bpm.ons.digital"
+    key                  = "lambdas/mail.tfstate"
+    region               = "eu-west-2"
+    workspace_key_prefix = "workspaces"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+data "aws_caller_identity" "current" {}
+
 locals  {
     prefix = "${var.app}-${var.stage}"
     attachments_bucket = "${local.prefix}-attachments.${var.domain}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals  {
     prefix = "${var.app}-${var.stage}"
-    attachments_bucket = "${local.prefix}-attachments-in.${var.domain}"
+    attachments_bucket = "${local.prefix}-attachments.${var.domain}"
     emails_bucket = "${local.prefix}-emails.${var.domain}"
 }
 

--- a/terraform/s3buckets.tf
+++ b/terraform/s3buckets.tf
@@ -1,0 +1,70 @@
+resource "aws_s3_bucket" "emails" {
+    bucket = local.emails_bucket
+    policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowEmailLambda",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                },
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::${local.emails_bucket}/*",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:SourceArn": "${aws_lambda_function.email.arn}"
+                    }
+                }
+            }
+        ]
+    }
+POLICY
+}
+
+resource "aws_s3_bucket" "attachments" {
+    bucket = local.attachments_bucket
+    policy = <<-POLICY
+    {
+        "Version":"2012-10-17",
+        "Statement":[
+            {
+            "Sid":"PublicRead",
+            "Effect":"Allow",
+            "Principal": "*",
+            "Action":["s3:GetObject"],
+            "Resource":["arn:aws:s3:::${local.attachments_bucket}/*"]
+            },
+            {
+                "Sid": "AllowEmailLambda",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                },
+                "Action": "s3:PutObject",
+                "Resource": "arn:aws:s3:::${local.emails_bucket}/*",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:SourceArn": "${aws_lambda_function.email.arn}"
+                    }
+                }
+            },
+            {
+                "Sid": "AllowEmailLambda",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                },
+                "Action": "s3:GetBucketLocation",
+                "Resource": "arn:aws:s3:::${local.emails_bucket}",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:SourceArn": "${aws_lambda_function.email.arn}"
+                    }
+                }
+            }
+        ]
+    }
+POLICY
+}

--- a/terraform/s3buckets.tf
+++ b/terraform/s3buckets.tf
@@ -5,16 +5,16 @@ resource "aws_s3_bucket" "emails" {
         "Version": "2012-10-17",
         "Statement": [
             {
-                "Sid": "AllowEmailLambda",
+                "Sid": "AllowSESPuts",
                 "Effect": "Allow",
                 "Principal": {
-                    "Service": "lambda.amazonaws.com"
+                    "Service": "ses.amazonaws.com"
                 },
-                "Action": "s3:GetObject",
+                "Action": "s3:PutObject",
                 "Resource": "arn:aws:s3:::${local.emails_bucket}/*",
                 "Condition": {
                     "StringEquals": {
-                        "aws:SourceArn": "${aws_lambda_function.email.arn}"
+                        "aws:Referer": "${data.aws_caller_identity.current.account_id}"
                     }
                 }
             }

--- a/terraform/s3buckets.tf
+++ b/terraform/s3buckets.tf
@@ -35,36 +35,36 @@ resource "aws_s3_bucket" "attachments" {
             "Principal": "*",
             "Action":["s3:GetObject"],
             "Resource":["arn:aws:s3:::${local.attachments_bucket}/*"]
-            },
-            {
-                "Sid": "AllowEmailLambda",
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Action": "s3:PutObject",
-                "Resource": "arn:aws:s3:::${local.emails_bucket}/*",
-                "Condition": {
-                    "StringEquals": {
-                        "aws:SourceArn": "${aws_lambda_function.email.arn}"
-                    }
-                }
-            },
-            {
-                "Sid": "AllowEmailLambda",
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Action": "s3:GetBucketLocation",
-                "Resource": "arn:aws:s3:::${local.emails_bucket}",
-                "Condition": {
-                    "StringEquals": {
-                        "aws:SourceArn": "${aws_lambda_function.email.arn}"
-                    }
-                }
             }
         ]
     }
+POLICY
+}
+
+resource "aws_iam_policy" "email-lambda-s3-policy" {
+    name        = "${local.prefix}-email-s3-lambda"
+    description = "Least privilege permissions for BPM Email ingress lambda"
+
+    policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${local.emails_bucket}/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${local.attachments_bucket}/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketLocation",
+            "Resource": "arn:aws:s3:::${local.attachments_bucket}"
+        }
+    ]
+}
 POLICY
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,0 +1,14 @@
+variable "app" {
+    type = string
+    default = "bpm-emails"
+}
+
+variable "stage" {
+    type = string
+    default = "dev"
+}
+
+variable "domain" {
+    type = string
+    default= "bpm.ons.digital"
+}


### PR DESCRIPTION
This PR adds the functionality to the lambda to extract any file attachments in the incoming email, and storing them in a new S3 bucket with public accessibility.

Files are stored with an unguessable URL, a la Gov Notify, which can be handed to BPM to display as links to the assigned worker, for them to download. The S3 objects have a Content-Disposition value set to "restore" the original filename on download.

Additionally, the HTML of the email body is now sanitised with [Bleach](https://github.com/mozilla/bleach).

Apologies for some of the changes coming from the use of [Black](https://github.com/psf/black) as the linter.