### PR TITLE
Fix destroy job - add permissions, fake zip for destroy

### DIFF
--- a/ci-bootstrap/terraform/role.tf.tmpl
+++ b/ci-bootstrap/terraform/role.tf.tmpl
@@ -100,7 +100,8 @@ data "aws_iam_policy_document" "bpm-deploy-lambda-policy" {
                 "iam:CreatePolicy",
                 "iam:AttachRolePolicy",
                 "iam:DeleteUserPolicy",
-                "iam:DeleteAccessKey"
+                "iam:DeleteAccessKey",
+                "iam:DeletePolicyVersion"
               ]
     resources = [
       "*"

--- a/ci-bootstrap/terraform/role.tf.tmpl
+++ b/ci-bootstrap/terraform/role.tf.tmpl
@@ -98,7 +98,9 @@ data "aws_iam_policy_document" "bpm-deploy-lambda-policy" {
                 "iam:PutUserPolicy",
                 "iam:GetUserPolicy",
                 "iam:CreatePolicy",
-                "iam:AttachRolePolicy"
+                "iam:AttachRolePolicy",
+                "iam:DeleteUserPolicy",
+                "iam:DeleteAccessKey"
               ]
     resources = [
       "*"

--- a/ci/tasks/terraform_destroy.sh
+++ b/ci/tasks/terraform_destroy.sh
@@ -13,6 +13,13 @@ set -euo pipefail
 . ./bpm-mail-lambda/ci/tasks/util/assume_role.sh
 . ./bpm-mail-lambda/ci/tasks/util/setup_terraform.sh
 
+# Generate fake deployment file to satisfy hash function
+# in terraform
+pushd ../../
+mkdir generated
+touch generated/function.zip
+popd
+
 terraform destroy --auto-approve
 
 echo "done"


### PR DESCRIPTION
This PR adds in some permissions that were missing with respect to the destroy pipeline job.

Additionally, the terraform hashing function used to provoke updating of the lambda zip choked during destroy, since the zip file had not been made. A zero bytes file is created during destroy that allows the function to execute.